### PR TITLE
Aligned ShellView code-behind and ShellViewModel to comply with MVVM

### DIFF
--- a/ElkaUWP.Core/ViewModels/ShellViewModel.cs
+++ b/ElkaUWP.Core/ViewModels/ShellViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using Windows.ApplicationModel.Core;
 using ElkaUWP.Core.Helpers;
@@ -12,23 +13,42 @@ using Prism.Navigation;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 using ElkaUWP.Infrastructure;
+using Prism.Services;
 using WinUI = Microsoft.UI.Xaml.Controls;
 
 namespace ElkaUWP.Core.ViewModels
 {
     public class ShellViewModel : BindableBase, INavigatedAware
     {
-        public INavigationService _internalNavigationService;
-        public INavigationService _externalNavigationService;
+        private INavigationService _internalNavigationService;
+        private INavigationService _externalNavigationService;
 
         public ShellViewModel()
         {
 
         }
 
-        public void Initialize()
+        /// <summary>
+        /// Called when View is loaded and internal navigation service can be created.
+        /// </summary>
+        public void Initialize(Frame internalFrame)
         {
+            _internalNavigationService = Prism.Navigation.NavigationService.Create(frame: internalFrame, Gesture.Back,
+                Gesture.Forward, Gesture.Refresh);
+        }
 
+        public async void RequestExternalNavigation(string navigationPath, INavigationParameters parameters = null)
+        {
+            if(parameters is null)
+                await _externalNavigationService.NavigateAsync(name: navigationPath);
+            else await _externalNavigationService.NavigateAsync(name: navigationPath, parameters: parameters);
+        }
+
+        public async void RequestInternalNavigation(string navigationPath, INavigationParameters parameters = null)
+        {
+            if (parameters is null)
+                await _internalNavigationService.NavigateAsync(name: navigationPath);
+            else await _internalNavigationService.NavigateAsync(name: navigationPath, parameters: parameters);
         }
 
         public void OnNavigatedFrom(INavigationParameters parameters)

--- a/ElkaUWP.Core/Views/ShellView.xaml
+++ b/ElkaUWP.Core/Views/ShellView.xaml
@@ -13,9 +13,9 @@
 
     <Grid>
         <NavigationView
-            x:Name="nvSample"
-            ItemInvoked="nvSample_ItemInvoked"
-            Loaded="nvSample_Loaded">
+            x:Name="Nv"
+            ItemInvoked="Nv_ItemInvoked"
+            Loaded="Nv_Loaded">
             <NavigationView.MenuItems>
                 <NavigationViewItem
                     Content="TestView"

--- a/ElkaUWP.Core/Views/ShellView.xaml.cs
+++ b/ElkaUWP.Core/Views/ShellView.xaml.cs
@@ -17,36 +17,34 @@ namespace ElkaUWP.Core.Views
     {
         private ShellViewModel ViewModel => DataContext as ShellViewModel;
 
-        public Frame ContentViewFrame => this.ContentFrame;
-
         public ShellView()
         {
             InitializeComponent();
             ViewModelLocator.SetAutowireViewModel(obj: this, value: true);
         }
 
-        private void nvSample_ItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
+        private void Nv_Loaded(object sender, RoutedEventArgs e)
         {
-            IEnumerable<NavigationViewItem> invokedItems = this.nvSample.MenuItems.Cast<NavigationViewItem>();
-            
-            NavigationViewItem invokedItem = invokedItems.FirstOrDefault(e => e.Content.Equals(args.InvokedItem));
+            // NavigationService for internal frame
+            ViewModel.Initialize(internalFrame: ContentFrame);
+        }
+
+        private async void Nv_ItemInvoked(NavigationView navigationView, NavigationViewItemInvokedEventArgs args)
+        {
+            // check if item belongs to Nv
+            var invokedItems = this.Nv.MenuItems.Cast<NavigationViewItem>();
+
+            var invokedItem = invokedItems.FirstOrDefault(e => e.Content.Equals(obj: args.InvokedItem));
 
             switch (invokedItem?.Tag)
             {
                 case "TestViewToken":
-                    (this.DataContext as ShellViewModel)._internalNavigationService.NavigateAsync(PageTokens.TestViewToken);
+                    ViewModel.RequestInternalNavigation(navigationPath: PageTokens.TestViewToken);
                     break;
                 case "LoginToken":
-                    (this.DataContext as ShellViewModel)._externalNavigationService.NavigateAsync(PageTokens.LoginViewToken);
+                    ViewModel.RequestExternalNavigation(navigationPath: PageTokens.TestViewToken);
                     break;
             }
-        }
-
-        private async void nvSample_Loaded(object sender, RoutedEventArgs e)
-        {
-            // NavigationService for internal frame
-            ViewModel._internalNavigationService = Prism.Navigation.NavigationService.Create(frame: ContentViewFrame, Gesture.Back,
-                Gesture.Forward, Gesture.Refresh);
         }
     }
 }


### PR DESCRIPTION
ShellView in its current implementiation should not be able to order navigation services. This PR fixes that by moving this responsibility to corresponding ViewModel. View may now only request navigation through appropriate public method.