### PR TITLE
Updated libraries references

### DIFF
--- a/ElkaUWP.Core/ElkaUWP.Core.csproj
+++ b/ElkaUWP.Core/ElkaUWP.Core.csproj
@@ -104,10 +104,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Anotar.NLog.Fody">
-      <Version>4.8.1</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="Fody">
-      <Version>4.2.1</Version>
+      <Version>5.0.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -115,16 +115,16 @@
       <Version>0.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.3</Version>
+      <Version>6.2.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Connectivity">
-      <Version>5.0.0</Version>
+      <Version>5.1.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Animations">
-      <Version>5.0.0</Version>
+      <Version>5.1.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
-      <Version>5.0.0</Version>
+      <Version>5.1.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
       <Version>2.0.181018003</Version>

--- a/ElkaUWP.DataLayer/ElkaUWP.DataLayer.csproj
+++ b/ElkaUWP.DataLayer/ElkaUWP.DataLayer.csproj
@@ -201,13 +201,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Anotar.NLog.Fody">
-      <Version>4.8.1</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="Equals.Fody">
-      <Version>1.9.3</Version>
+      <Version>2.0.0</Version>
     </PackageReference>
     <PackageReference Include="Fody">
-      <Version>4.2.1</Version>
+      <Version>5.0.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -218,10 +218,10 @@
       <Version>0.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.3</Version>
+      <Version>6.2.8</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.1</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="NLog">
       <Version>4.6.2</Version>
@@ -230,7 +230,7 @@
       <Version>7.2.0.853-ci</Version>
     </PackageReference>
     <PackageReference Include="Syncfusion.SfSchedule.UWP">
-      <Version>17.1.0.41</Version>
+      <Version>17.1.0.42</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/ElkaUWP.Infrastructure/ElkaUWP.Infrastructure.csproj
+++ b/ElkaUWP.Infrastructure/ElkaUWP.Infrastructure.csproj
@@ -154,10 +154,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Anotar.NLog.Fody">
-      <Version>4.8.1</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="Fody">
-      <Version>4.2.1</Version>
+      <Version>5.0.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -165,10 +165,10 @@
       <Version>0.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.3</Version>
+      <Version>6.2.8</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.1</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="NLog">
       <Version>4.6.2</Version>

--- a/Modules/ElkaUWP.Modularity.CalendarModule/ElkaUWP.Modularity.CalendarModule.csproj
+++ b/Modules/ElkaUWP.Modularity.CalendarModule/ElkaUWP.Modularity.CalendarModule.csproj
@@ -134,10 +134,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Anotar.NLog.Fody">
-      <Version>4.8.1</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="Fody">
-      <Version>4.2.1</Version>
+      <Version>5.0.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -145,10 +145,10 @@
       <Version>0.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.3</Version>
+      <Version>6.2.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
-      <Version>5.0.0</Version>
+      <Version>5.1.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
       <Version>2.0.181018003</Version>
@@ -166,7 +166,7 @@
       <Version>7.2.0.853-ci</Version>
     </PackageReference>
     <PackageReference Include="Syncfusion.SfSchedule.UWP">
-      <Version>17.1.0.41</Version>
+      <Version>17.1.0.42</Version>
     </PackageReference>
     <PackageReference Include="Telerik.UI.for.UniversalWindowsPlatform">
       <Version>1.0.1.4</Version>

--- a/Modules/ElkaUWP.Modularity.GradesModule/ElkaUWP.Modularity.GradesModule.csproj
+++ b/Modules/ElkaUWP.Modularity.GradesModule/ElkaUWP.Modularity.GradesModule.csproj
@@ -142,10 +142,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Anotar.NLog.Fody">
-      <Version>4.8.1</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="Fody">
-      <Version>4.2.1</Version>
+      <Version>5.0.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -153,10 +153,10 @@
       <Version>0.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.3</Version>
+      <Version>6.2.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
-      <Version>5.0.0</Version>
+      <Version>5.1.1</Version>
     </PackageReference>
     <PackageReference Include="Nito.Mvvm.Async">
       <Version>1.0.0-pre-03</Version>
@@ -168,10 +168,10 @@
       <Version>7.2.0.853-ci</Version>
     </PackageReference>
     <PackageReference Include="Syncfusion.SfGrid.UWP">
-      <Version>17.1.0.41</Version>
+      <Version>17.1.0.42</Version>
     </PackageReference>
     <PackageReference Include="Syncfusion.SfSchedule.UWP">
-      <Version>17.1.0.41</Version>
+      <Version>17.1.0.42</Version>
     </PackageReference>
     <PackageReference Include="Telerik.UI.for.UniversalWindowsPlatform">
       <Version>1.0.1.4</Version>

--- a/Modules/ElkaUWP.Modularity.LoginModule/ElkaUWP.Modularity.LoginModule.csproj
+++ b/Modules/ElkaUWP.Modularity.LoginModule/ElkaUWP.Modularity.LoginModule.csproj
@@ -145,10 +145,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Anotar.NLog.Fody">
-      <Version>4.8.1</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="Fody">
-      <Version>4.2.1</Version>
+      <Version>5.0.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -156,16 +156,16 @@
       <Version>0.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.3</Version>
+      <Version>6.2.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Connectivity">
-      <Version>5.0.0</Version>
+      <Version>5.1.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Animations">
-      <Version>5.0.0</Version>
+      <Version>5.1.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
-      <Version>5.0.0</Version>
+      <Version>5.1.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
       <Version>2.0.181018003</Version>

--- a/Modules/ElkaUWP.Modularity.UserModule/ElkaUWP.Modularity.UserModule.csproj
+++ b/Modules/ElkaUWP.Modularity.UserModule/ElkaUWP.Modularity.UserModule.csproj
@@ -131,10 +131,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.3</Version>
+      <Version>6.2.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
-      <Version>5.0.0</Version>
+      <Version>5.1.1</Version>
     </PackageReference>
     <PackageReference Include="Nito.Mvvm.Async">
       <Version>1.0.0-pre-03</Version>


### PR DESCRIPTION
I have updated libraries references to allow for using newest features and most importantly go away with buggy UWP NETCore 6.2.3 version.